### PR TITLE
Add cabal file for exposing arbitrary.

### DIFF
--- a/test/delorean-test.cabal
+++ b/test/delorean-test.cabal
@@ -1,0 +1,13 @@
+name:                  delorean-test
+version:               0.0.1
+cabal-version:         >= 1.8
+
+library
+  build-depends:
+                       base
+                     , p
+                     , delorean
+                     , QuickCheck
+
+  exposed-modules:
+                       Delorean.Arbitrary


### PR DESCRIPTION
@charleso As discussed. Here is what I think is the best approach and doesn't affect the dev cycle, specific rules:
- Minimal cabal cruft
- Expose just the test tooling, arbitraries etc..
- Minimal set of dependencies, no versions. The consumers of this would be depending on the main library anyway which will lock down the versions without having us duplicate here. 

Issues:
- It means that any test dependency has to be added to two cabal files.
- Pain to test/verify.

I have tested this with hydra and works ok, real question is the trade-off of not depending on QuickCheck on src tree worth the dupe.

Only other alternative I can think of is to build an extra tool to generate this file.
