### PR TITLE
Bump attoparsec to the current 0.13

### DIFF
--- a/delorean.cabal
+++ b/delorean.cabal
@@ -13,7 +13,7 @@ description:           delorean.
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , attoparsec                      >= 0.11       && < 0.13
+                     , attoparsec                      >= 0.11       && < 0.14
                      , p
                      , x-templatehaskell
                      , template-haskell


### PR DESCRIPTION
Not much to see, but 0.13 (the current release) is required for more recent versions of aeson.
