### PR TITLE
Date parser shouldn't reject valid years

### DIFF
--- a/src/Delorean/Local/Date.hs
+++ b/src/Delorean/Local/Date.hs
@@ -123,6 +123,7 @@ yearToInt :: Year -> Int
 yearToInt =
   unYear
 
+-- | Parses a valid year for the Gregorian calendar, i.e., in or after 1600.
 yearFromInt :: Int -> Maybe Year
 yearFromInt n =
   valueOrEmpty (n >= 1600) $ Year n


### PR DESCRIPTION
It seems intuitive to me that a function called `yearFromInt` will work for all valid years; is there a reason for rejecting everything before 1600? (If there's a need for a function which rejects dates which are implausible for some application, my instinct would be to make that a separate thing with a clear name; I'm fine with leaving it if others disagree, but it should at least be documented.)

/cc @nhibberd @charleso 