### PR TITLE
Support for MaxML - add Read instances to all data types.

### DIFF
--- a/src/Delorean/Duration.hs
+++ b/src/Delorean/Duration.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Delorean.Duration (
@@ -9,9 +10,11 @@ module Delorean.Duration (
   ) where
 
 import           Data.Attoparsec.Text
+import           Data.Data (Data)
+import           Data.String (String)
 import           Data.Text (Text)
 import qualified Data.Text as T
-import           Data.String (String)
+import           Data.Typeable (Typeable)
 
 import           P
 
@@ -19,7 +22,7 @@ data Duration =
     Seconds Int
   | Minutes Int
   | Hours Int
-  deriving (Show)
+  deriving (Read, Show, Typeable, Data)
 
 instance Eq Duration where
   (==) = on (==) durationToSeconds

--- a/src/Delorean/Local/Date.hs
+++ b/src/Delorean/Local/Date.hs
@@ -73,7 +73,7 @@ import           Text.Printf (printf)
 newtype Year =
   Year {
     unYear :: Int
-  } deriving (Eq, Show, Ord, Enum, Bounded, Typeable, Data)
+  } deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data)
 
 data Month =
     January
@@ -88,12 +88,12 @@ data Month =
   | October
   | November
   | December
-  deriving (Eq, Show, Ord, Enum, Bounded, Typeable, Data)
+  deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data)
 
 newtype DayOfMonth =
   DayOfMonth {
     unDayOfMonth :: Int
-  } deriving (Eq, Show, Ord, Enum, Bounded, Typeable, Data)
+  } deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data)
 
 data DayOfWeek =
     Sunday
@@ -103,7 +103,7 @@ data DayOfWeek =
   | Thursday
   | Friday
   | Saturday
-  deriving (Eq, Show, Ord, Enum, Bounded, Typeable, Data)
+  deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data)
 
 data WeekOfMonth =
     FirstWeek
@@ -111,14 +111,14 @@ data WeekOfMonth =
   | ThirdWeek
   | FourthWeek
   | LastWeek
-  deriving (Eq, Show, Ord, Enum, Bounded, Typeable, Data)
+  deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data)
 
 data Date =
   Date {
     dateYear :: !Year
   , dateMonth :: !Month
   , dateDay :: !DayOfMonth
-  } deriving (Eq, Show, Ord, Typeable, Data)
+  } deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 yearToInt :: Year -> Int
 yearToInt =

--- a/src/Delorean/Local/DateTime.hs
+++ b/src/Delorean/Local/DateTime.hs
@@ -37,7 +37,7 @@ data DateTime =
   DateTime {
     getDate :: !Date
   , getTime :: !Time
-  } deriving (Eq, Show, Ord, Typeable, Data)
+  } deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 dateTime :: Year -> Month -> DayOfMonth -> HourOfDay -> MinuteOfHour -> SecondOfMinute -> DateTime
 dateTime y m dom hod moh som =

--- a/src/Delorean/Local/Time.hs
+++ b/src/Delorean/Local/Time.hs
@@ -40,24 +40,24 @@ import           Text.Printf
 newtype HourOfDay =
   HourOfDay {
     unHourOfDay :: Int
-  } deriving (Eq, Show, Ord, Enum, Bounded, Typeable, Data)
+  } deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data)
 
 newtype MinuteOfHour =
   MinuteOfHour {
     unMinuteOfHour :: Int
-  } deriving (Eq, Show, Ord, Enum, Bounded, Typeable, Data)
+  } deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data)
 
 newtype SecondOfMinute =
   SecondOfMinute {
     unSecondOfMinute :: Int
-  } deriving (Eq, Show, Ord, Enum, Bounded, Typeable, Data)
+  } deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data)
 
 data Time =
   Time {
     timeHour :: !HourOfDay
   , timeMinute :: !MinuteOfHour
   , timeSecond :: !SecondOfMinute
-  } deriving (Eq, Show, Ord, Typeable, Data)
+  } deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 hourOfDayFromInt :: Int -> Maybe HourOfDay
 hourOfDayFromInt n =


### PR DESCRIPTION
This might seem silly, but it's really useful to have data types that support MaxML when you get a failing quickcheck test.