### PR TITLE
Strict data types

### DIFF
--- a/delorean.cabal
+++ b/delorean.cabal
@@ -24,7 +24,7 @@ library
                      , tzdata                          == 0.1.*
 
   ghc-options:
-                       -Wall
+                       -Wall -funbox-strict-fields
 
   hs-source-dirs:
                        src

--- a/src/Delorean/Local/Date.hs
+++ b/src/Delorean/Local/Date.hs
@@ -115,9 +115,9 @@ data WeekOfMonth =
 
 data Date =
   Date {
-    dateYear :: Year
-  , dateMonth :: Month
-  , dateDay :: DayOfMonth
+    dateYear :: !Year
+  , dateMonth :: !Month
+  , dateDay :: !DayOfMonth
   } deriving (Eq, Show, Ord, Typeable, Data)
 
 yearToInt :: Year -> Int

--- a/src/Delorean/Local/DateTime.hs
+++ b/src/Delorean/Local/DateTime.hs
@@ -35,8 +35,8 @@ import           System.IO
 
 data DateTime =
   DateTime {
-    getDate :: Date
-  , getTime :: Time
+    getDate :: !Date
+  , getTime :: !Time
   } deriving (Eq, Show, Ord, Typeable, Data)
 
 dateTime :: Year -> Month -> DayOfMonth -> HourOfDay -> MinuteOfHour -> SecondOfMinute -> DateTime

--- a/src/Delorean/Local/Time.hs
+++ b/src/Delorean/Local/Time.hs
@@ -54,9 +54,9 @@ newtype SecondOfMinute =
 
 data Time =
   Time {
-    timeHour :: HourOfDay
-  , timeMinute :: MinuteOfHour
-  , timeSecond :: SecondOfMinute
+    timeHour :: !HourOfDay
+  , timeMinute :: !MinuteOfHour
+  , timeSecond :: !SecondOfMinute
   } deriving (Eq, Show, Ord, Typeable, Data)
 
 hourOfDayFromInt :: Int -> Maybe HourOfDay


### PR DESCRIPTION
I can't think of a good reason why these shouldn't be strict, and unboxing them will make them use less memory and require fewer indirections.

I would be pretty keen for us to start making data types strict by default, and only make them lazy where there's a good reason to.