### PR TITLE
Inconsistent flags usage

### DIFF
--- a/delorean.cabal
+++ b/delorean.cabal
@@ -24,7 +24,7 @@ library
                      , tzdata                          == 0.1.*
 
   ghc-options:
-                       -Wall -funbox-strict-fields
+                       -Wall
 
   hs-source-dirs:
                        src

--- a/src/Delorean/Duration.hs
+++ b/src/Delorean/Duration.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
 module Delorean.Duration (
     Duration (..)
   , durationToSeconds
@@ -19,9 +20,9 @@ import           Data.Typeable (Typeable)
 import           P
 
 data Duration =
-    Seconds Int
-  | Minutes Int
-  | Hours Int
+    Seconds !Int
+  | Minutes !Int
+  | Hours !Int
   deriving (Read, Show, Typeable, Data)
 
 instance Eq Duration where

--- a/src/Delorean/Local/Date.hs
+++ b/src/Delorean/Local/Date.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
 module Delorean.Local.Date (
     Year
   , Month (..)

--- a/src/Delorean/Local/DateTime.hs
+++ b/src/Delorean/Local/DateTime.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
 module Delorean.Local.DateTime (
     DateTime (..)
   , dateTime

--- a/src/Delorean/Local/Time.hs
+++ b/src/Delorean/Local/Time.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
 module Delorean.Local.Time (
     HourOfDay
   , MinuteOfHour


### PR DESCRIPTION
I realised when I started writing up some guidelines for strictness/unboxing that it was a bit inconsistent to put `-funbox-strict-fields` in the .cabal file, as we don't do that for other flags (like `-fno-warn-orphans`).